### PR TITLE
Changed syntax of free text output of multimers and associated unit test

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -42,7 +42,7 @@ def test_build_valid_multimer_strings_one():
     args.append(create_input_list(args_2))
     assert (
         build_valid_multimers_strings(args)
-        == "Tet1: HLA-A*01:01, NLVP + oxidized residue, amidated residue (N1, P4)"
+        == "Tet1: HLA-A*01:01, NLVP + oxidized residue (N1), amidated residue (P4)"
     )
 
 
@@ -86,7 +86,9 @@ def test_build_valid_multimer_strings_three():
         == "Tet1: HLA-A*01:01, NLVATY + dehydrated residue (T5)\nTet2: H2-Db, NLMMY + acetylated residue (M4)"
     )
 
+
 # One empty entry and one valid entry
+
 
 def test_build_valid_multimer_strings_four():
     args_1 = {

--- a/tetramer_validator/server.py
+++ b/tetramer_validator/server.py
@@ -105,9 +105,13 @@ def build_valid_multimers_strings(inputs):
         if not bool(input["errors"]) and len(input["success"]) > 1:
             x = x + 1
             if input["mod_pos"] and input["mod_type"]:
+                types = input["mod_type"].strip().replace(", ", ",").split(",")
+                positions = input["mod_pos"].strip().replace(", ", ",").split(",")
+                type_pos = tuple(zip(types, positions))
+                type_pos = [f"{type} ({pos})" for type, pos in type_pos]
+                type_pos = ", ".join(type_pos)
                 valid_multimers.append(
-                    f"Tet{x}: {input['mhc_name']}, {input['pep_seq']}"
-                    f" + {input['mod_type']} ({input['mod_pos']})"
+                    f"Tet{x}: {input['mhc_name']}, {input['pep_seq']} + {type_pos}"
                 )
             else:
                 valid_multimers.append(


### PR DESCRIPTION
Instead of having each all modification types followed by all modification positions, in parenthesis, each modification type follows a modification position, which is in parenthesis.

Example:
`GET` query: `?mhc_name=HLA-DRB1*04%3A01&pep_seq=DAGWLADQTVRYPIHT&mod_type=L-citrylline%2C+L-citrylline&mod_pos=R11%2C+D1&mhc_name=HLA-DQA1*01%3A02%2FDQB1*06%3A02&pep_seq=ASGNHAAGILTM&mod_type=amidated+residue&mod_pos=M7`

Free Text output before: `Tet1: HLA-DRB1*04:01, DAGWLADQTVRYPIHT + L-citrylline, L-citrylline (R11, D1)`

New Syntax: `Tet1: HLA-DRB1*04:01, DAGWLADQTVRYPIHT + L-citrylline (R11), L-citrylline (D1)`