### PR TITLE
Gitlab CI added for builds & deployments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,66 @@
+stages:
+  - build
+  - deploy
+
+# build and push container at tip of each branch - embed commit sha and other info into labels somewhere
+# this should happen on each commit (except: tags)
+
+# deploy to production
+# this should be manual and should pull from a tagged version
+
+# deploy to dev
+# this should be manual and should pull from one of the branches
+
+.build_container: &build_container
+  - REF_NAME=$(echo $CI_COMMIT_REF_NAME | tr '/' '_' | awk '{print tolower($0)}')
+  - docker build -t $CI_REGISTRY_IMAGE:$REF_NAME --label git_url=$CI_REPOSITORY_URL --label pipeline_url=$CI_PIPELINE_URL --label commit_sha=$CI_COMMIT_SHA .
+
+.push_container: &push_container
+  - docker push $CI_REGISTRY_IMAGE:$REF_NAME
+
+.rancher_login: &rancher_login
+  - rancher login -t "${RANCHER_API_TOKEN}" "${RANCHER_URL}" --context "${RANCHER_PROJECT_CONTEXT}"
+
+.rancher_rollout: &rancher_rollout
+  - rancher kubectl rollout restart deployment --namespace "${RANCHER_NAMESPACE}" "${RANCHER_WORKLOAD}"
+
+
+build_and_push:
+  stage: build
+  services:
+    - docker:dind
+  script:
+    - *build_container
+    - *push_container
+
+# tag the image as a production image, in preparation for deployment
+tag_production:
+  stage: build
+  services:
+    - docker:dind
+    - docker pull $CI_REGISTRY_IMAGE:$REF_NAME
+    - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:production
+    - docker push $CI_REGISTRY_IMAGE:production
+  only:
+    - tags
+
+# deploy to production
+# ideally we could automate this and only have tags deployd
+# for now we set it to manual
+deploy_prod:
+  stage: deploy
+  image: gitlab.lji.org:4567/sysadminscorner/public/rancher-kubectl:master
+  when: manual
+  script:
+    - RANCHER_URL=https://rancher.lji.org/v3
+    - RANCHER_PROJECT_CONTEXT=c-qprnb:p-8vppd
+    - RANCHER_NAMESPACE=tetramer-validator
+    - RANCHER_WORKLOAD=tetramer-validator-prod
+    - *rancher_login
+    - *rancher_rollout
+
+# deploy to dev
+deploy_dev:
+  stage: deploy
+  image: gitlab.lji.org:4567/sysadminscorner/public/rancher-kubectl:master
+  when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,4 @@
+image: docker:19.03.11
 stages:
   - build
   - deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ tag_production:
   stage: build
   services:
     - docker:dind
+  script:
     - docker pull $CI_REGISTRY_IMAGE:$REF_NAME
     - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:production
     - docker push $CI_REGISTRY_IMAGE:production

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,8 +26,6 @@ stages:
   - docker push $CI_REGISTRY_IMAGE:$REF_NAME
 
 .tag_image: &tag_image
-  - *docker_login
-  - *get_ref_name
   - docker pull $CI_REGISTRY_IMAGE:$REF_NAME
   - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:$TAG_NAME
   - docker push $CI_REGISTRY_IMAGE:$TAG_NAME
@@ -65,6 +63,8 @@ tag_production:
     - docker:dind
   script:
     - TAG_NAME=production
+    - *docker_login
+    - *get_ref_name
     - *tag_image
   when: manual
 
@@ -92,6 +92,8 @@ tag_dev:
     - docker:dind
   script:
     - TAG_NAME=dev
+    - *docker_login
+    - *get_ref_name
     - *tag_image
   when: manual
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,13 @@ stages:
 .push_container: &push_container
   - docker push $CI_REGISTRY_IMAGE:$REF_NAME
 
+.tag_image: &tag_image
+  - *docker_login
+  - *get_ref_name
+  - docker pull $CI_REGISTRY_IMAGE:$REF_NAME
+  - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:$TAG_NAME
+  - docker push $CI_REGISTRY_IMAGE:$TAG_NAME
+
 .rancher_login: &rancher_login
   - rancher login -t "${RANCHER_API_TOKEN}" "${RANCHER_URL}" --context "${RANCHER_PROJECT_CONTEXT}"
 
@@ -40,7 +47,6 @@ stages:
   - rancher kubectl rollout history deployment --namespace "${RANCHER_NAMESPACE}" "${RANCHER_WORKLOAD}"
 
 
-
 build_and_push:
   stage: build
   services:
@@ -51,36 +57,55 @@ build_and_push:
     - *docker_login
     - *push_container
 
+
 # tag the image as a production image, in preparation for deployment
 tag_production:
   stage: tag
   services:
     - docker:dind
   script:
-    - *docker_login
-    - *get_ref_name
-    - docker pull $CI_REGISTRY_IMAGE:$REF_NAME
-    - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:production
-    - docker push $CI_REGISTRY_IMAGE:production
+    - TAG_NAME=production
+    - *tag_image
   when: manual
 
-# deploy to production
-# ideally we could automate this and only have tags deployd
-# for now we set it to manual
+# deploy to production - this requires the 'production' tag
+# the 'needs' tag allows the deployment step to run without waiting for
+# the building/tagging to work.  This is so that one can simply run deploy
+# on a pre-exisisting container;
 deploy_prod:
   stage: deploy
   image: gitlab.lji.org:4567/sysadminscorner/public/rancher-kubectl:master
   when: manual
+  needs: []
   script:
-    - RANCHER_URL=https://rancher.lji.org/v3
     - RANCHER_PROJECT_CONTEXT=c-qprnb:p-8vppd
+    - RANCHER_URL=https://rancher.lji.org/v3
     - RANCHER_NAMESPACE=tetramer-validator
     - RANCHER_WORKLOAD=tetramer-validator-prod
     - *rancher_login
     - *rancher_rollout
 
-# # deploy to dev
-# deploy_dev:
-#   stage: deploy
-#   image: gitlab.lji.org:4567/sysadminscorner/public/rancher-kubectl:master
-#   when: manual
+# tag the image as a dev image, in preparation for deployment
+tag_dev:
+  stage: tag
+  services:
+    - docker:dind
+  script:
+    - TAG_NAME=dev
+    - *tag_image
+  when: manual
+
+
+# deploy to dev - similar config to prod
+deploy_dev:
+  stage: deploy
+  image: gitlab.lji.org:4567/sysadminscorner/public/rancher-kubectl:master
+  when: manual
+  needs: []
+  script:
+    - RANCHER_PROJECT_CONTEXT=c-qprnb:p-8vppd
+    - RANCHER_URL=https://rancher.lji.org/v3
+    - RANCHER_NAMESPACE=tetramer-validator
+    - RANCHER_WORKLOAD=tetramer-validator-dev
+    - *rancher_login
+    - *rancher_rollout

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 image: docker:19.03.11
 stages:
   - build
+  - tag
   - deploy
 
 # build and push container at tip of each branch - embed commit sha and other info into labels somewhere
@@ -40,7 +41,7 @@ build_and_push:
 
 # tag the image as a production image, in preparation for deployment
 tag_production:
-  stage: build
+  stage: tag
   services:
     - docker:dind
   script:
@@ -48,7 +49,6 @@ tag_production:
     - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:production
     - *docker_login
     - docker push $CI_REGISTRY_IMAGE:production
-  needs: ['build_and_push']
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,10 +48,10 @@ tag_production:
   services:
     - docker:dind
   script:
+    - *docker_login
     - *get_ref_name
     - docker pull $CI_REGISTRY_IMAGE:$REF_NAME
     - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:production
-    - *docker_login
     - docker push $CI_REGISTRY_IMAGE:production
   when: manual
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,7 @@ tag_production:
     - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:production
     - *docker_login
     - docker push $CI_REGISTRY_IMAGE:production
+  needs: ['build_and_push']
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,8 @@ stages:
   - build
   - tag
   - deploy
+variables:
+
 
 # build and push container at tip of each branch - embed commit sha and other info into labels somewhere
 # this should happen on each commit (except: tags)
@@ -13,11 +15,14 @@ stages:
 # deploy to dev
 # this should be manual and should pull from one of the branches
 
+.get_ref_name: &get_ref_name
+  - REF_NAME=$(echo $CI_COMMIT_REF_NAME | tr '/' '_' | awk '{print tolower($0)}')
+
 .docker_login: &docker_login
+  - *get_ref_name
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
 
 .build_container: &build_container
-  - REF_NAME=$(echo $CI_COMMIT_REF_NAME | tr '/' '_' | awk '{print tolower($0)}')
   - docker build -t $CI_REGISTRY_IMAGE:$REF_NAME --label git_url=$CI_REPOSITORY_URL --label pipeline_url=$CI_PIPELINE_URL --label commit_sha=$CI_COMMIT_SHA .
 
 .push_container: &push_container
@@ -45,12 +50,12 @@ tag_production:
   services:
     - docker:dind
   script:
+    - *get_ref_name
     - docker pull $CI_REGISTRY_IMAGE:$REF_NAME
     - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:production
     - *docker_login
     - docker push $CI_REGISTRY_IMAGE:production
-  only:
-    - tags
+  when: manual
 
 # deploy to production
 # ideally we could automate this and only have tags deployd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,8 +60,8 @@ deploy_prod:
     - *rancher_login
     - *rancher_rollout
 
-# deploy to dev
-deploy_dev:
-  stage: deploy
-  image: gitlab.lji.org:4567/sysadminscorner/public/rancher-kubectl:master
-  when: manual
+# # deploy to dev
+# deploy_dev:
+#   stage: deploy
+#   image: gitlab.lji.org:4567/sysadminscorner/public/rancher-kubectl:master
+#   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,9 @@ stages:
 # deploy to dev
 # this should be manual and should pull from one of the branches
 
+.docker_login: &docker_login
+  - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+
 .build_container: &build_container
   - REF_NAME=$(echo $CI_COMMIT_REF_NAME | tr '/' '_' | awk '{print tolower($0)}')
   - docker build -t $CI_REGISTRY_IMAGE:$REF_NAME --label git_url=$CI_REPOSITORY_URL --label pipeline_url=$CI_PIPELINE_URL --label commit_sha=$CI_COMMIT_SHA .
@@ -32,6 +35,7 @@ build_and_push:
     - docker:dind
   script:
     - *build_container
+    - *docker_login
     - *push_container
 
 # tag the image as a production image, in preparation for deployment
@@ -42,6 +46,7 @@ tag_production:
   script:
     - docker pull $CI_REGISTRY_IMAGE:$REF_NAME
     - docker tag $CI_REGISTRY_IMAGE:$REF_NAME $CI_REGISTRY_IMAGE:production
+    - *docker_login
     - docker push $CI_REGISTRY_IMAGE:production
   only:
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,6 @@ stages:
   - build
   - tag
   - deploy
-variables:
-
 
 # build and push container at tip of each branch - embed commit sha and other info into labels somewhere
 # this should happen on each commit (except: tags)
@@ -19,7 +17,6 @@ variables:
   - REF_NAME=$(echo $CI_COMMIT_REF_NAME | tr '/' '_' | awk '{print tolower($0)}')
 
 .docker_login: &docker_login
-  - *get_ref_name
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
 
 .build_container: &build_container
@@ -40,6 +37,7 @@ build_and_push:
   services:
     - docker:dind
   script:
+    - *get_ref_name
     - *build_container
     - *docker_login
     - *push_container

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,15 @@ stages:
 
 .rancher_rollout: &rancher_rollout
   - rancher kubectl rollout restart deployment --namespace "${RANCHER_NAMESPACE}" "${RANCHER_WORKLOAD}"
+  # annotate this deployment in kube with the commit sha. Note the - > in yaml causes the following linebreaks to treat this as one line (replace newline with space)
+  - >
+      rancher kubectl annotate deployment --namespace "${RANCHER_NAMESPACE}" "${RANCHER_WORKLOAD}"
+      kubernetes.io/change-cause="${CI_COMMIT_SHORT_SHA} - ${CI_COMMIT_TITLE} - ${CI_PIPELINE_URL}" --record=false --overwrite=true
+  # check and wait on deployment for successful deploy and set timeout after 120 seconds
+  - rancher kubectl rollout status deployment --namespace "${RANCHER_NAMESPACE}" "${RANCHER_WORKLOAD}" --timeout=120s
+  # show rollout history
+  - rancher kubectl rollout history deployment --namespace "${RANCHER_NAMESPACE}" "${RANCHER_WORKLOAD}"
+
 
 
 build_and_push:

--- a/tetramer_validator/server.py
+++ b/tetramer_validator/server.py
@@ -240,5 +240,5 @@ def allowed_file(filename):
     return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
 
-# if __name__ == '__main__':
-#    app.run(host='0.0.0.0', debug=True)
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', debug=True)


### PR DESCRIPTION
CI has been added to take care of builds and deployments.  Here's how it's working:

- Upon commit to any branch a container is built and pushed to the gitlab registry and tagged with that branch name.  This means we'll have a container that lives at the tip of each branch.
- The 'tag_production' and 'tag_dev' jobs can be kicked off manually and will take the image that was built from the current commit, tag it as 'production' or 'dev' and push it back to the gitlab registry.
- The 'deploy_production' and 'deploy_dev' jobs can also be kicked off manually and will toggle the LJI Rancher instance to pull the 'production' or 'dev' tag of the container and restart the services.  Note that this last step is independent of the previous two so that, e.g., you can always toggle this to deploy whatever image is currently tagged as 'production' or 'dev'.  Once deployed, the production container will be at http://tetramers.iedb.org and the dev container will be at http://tetramers-dev.internal.iedb.org.  You'll likely need to be on the 'LJI ALL' VPN to view the dev container.  The production container is also redirected to from http://tools.iedb.org/mhcmultimer.

Looping @jamesaoverton here as well as I'd like to consider moving this project into our gitlab instance rather than mirroring.  It's not absolutely critical, but it would make for quicker deployments and make CI testing a bit easier.

Those are the basics, but happy to discuss further.

-J