### PR TITLE
Prevent a duplicate modification position 

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -40,6 +40,7 @@ def test_validate_PTM_names_one():
 def test_validate_PTM_names_two():
     assert validate_PTM_names(["oxidized residue"]) == []
 
+
 def test_validate_PTM_names_three():
     assert validate_PTM_names(["ox"]) == [
         {
@@ -49,10 +50,9 @@ def test_validate_PTM_names_three():
             "message": f"ox is a lower case string for OX.",
             "field": "mod_type",
             "suggestion": "oxidized residue",
-
         }
-
     ]
+
 
 def test_validate_PTM_names_four():
     assert validate_PTM_names(["OX"]) == [
@@ -64,8 +64,6 @@ def test_validate_PTM_names_four():
             "message": f"OX is a synonym for oxidized residue.",
             "suggestion": "oxidized residue",
         }
-
-
     ]
 
 
@@ -261,6 +259,7 @@ def test_validate_mod_pos_syntax_five():
         }
     ]
 
+
 def test_validate_mod_pos_syntax_six():
     assert validate_mod_pos_syntax(pep_seq="fff", positions="mra") == [
         {
@@ -274,6 +273,7 @@ def test_validate_mod_pos_syntax_six():
             "suggestion": None,
         }
     ]
+
 
 def test_validate_peptide_one():
     assert validate_peptide(
@@ -309,6 +309,24 @@ def test_validate_peptide_two():
             "suggestion": None,
         }
     ]
+
+
+def test_validate_peptide_three():
+    assert validate_peptide(
+        pep_seq="MMMMMMMMMMMMMMMMMMMMMMMMMMMMM",
+        mod_pos="M6,M6,M6",
+        mod_type="formylated residue,formylated residue,formylated residue",
+    ) == [
+        {
+            "level": "warn",
+            "rule": "DupModPos",
+            "value": "M6",
+            "message": "M6 appears more than once in modification positions.",
+            "field": "mod_pos",
+            "suggestion": None,
+        }
+    ]
+
 
 def test_properNumArguments_one():
     assert properNumArguments(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -359,7 +359,6 @@ def test_validate_mod_pos_syntax_eleven():
     ]
 
 
-
 def test_validate_peptide_one():
     assert validate_peptide(
         pep_seq="NLVPMVATV",
@@ -395,6 +394,7 @@ def test_validate_peptide_two():
         }
     ]
 
+
 def test_validate_peptide_three():
     assert validate_peptide(
         pep_seq="MMMMMMMMMMMMMMMMMMMMMMMMMMMMM",
@@ -405,7 +405,8 @@ def test_validate_peptide_three():
             "level": "warn",
             "rule": "DupModPos",
             "value": "M6",
-            "message": "M6 appears more than once in modification positions.",
+            "message": "M6 with same modification type formylated residue "
+            "appears more than once in modification positions.",
             "field": "mod_pos",
             "suggestion": None,
         }

--- a/tetramer_validator/validate.py
+++ b/tetramer_validator/validate.py
@@ -463,17 +463,18 @@ def validate_modification(pep_seq, mod_pos, mod_type):
         pos_type_match = Counter(zip(positions, mod_types))
         dup, no_dup = [], []
         for pos in pos_type_match.items():
-            (no_dup, dup)[pos_type_match[1] > 1].append(pos_type_match[0])
+            (no_dup, dup)[pos[1] > 1].append(pos[0])
         dup_mod = "DupModPos"
         dup = set(dup)
         for pos in dup:
+            print(pos[0])
             errors.append(
                 {
                     "level": "warn",
                     "rule": dup_mod,
-                    "value": pos,
+                    "value": pos[0],
                     "field": "mod_pos",
-                    "message": f"{pos} with same modification type appears"
+                    "message": f"{pos[0]} with same modification type {pos[1]} appears"
                     " more than once in modification positions.",
                     "suggestion": None,
                 }

--- a/tetramer_validator/validate.py
+++ b/tetramer_validator/validate.py
@@ -302,7 +302,7 @@ def validate_mod_pos_syntax(pep_seq, positions):
                 "Modification Position field should be a comma separated list of amino acid "
                 "letters followed by position numbers (e.g. F1, S10, S300). "
             )
-            formatted_string_zero_index = f"Zero-based indexing is not allowed. "
+            formatted_string_zero_index = "Zero-based indexing is not allowed. "
             if re.fullmatch(pattern=digits, string=pos):
                 if int(pos) > len(pep_seq):
                     errors.append(
@@ -458,10 +458,12 @@ def validate_modification(pep_seq, mod_pos, mod_type):
     errors.extend(validate_mod_pos(pep_seq, positions))
     if not errors:
         positions, mod_types = format_mod_info(mod_pos, mod_type)
-        positions = Counter(positions.split(","))
+        positions = positions.split(",")
+        mod_types = mod_types.split(",")
+        pos_type_match = Counter(zip(positions, mod_types))
         dup, no_dup = [], []
-        for pos in positions.items():
-            (no_dup, dup)[pos[1] > 1].append(pos[0])
+        for pos in pos_type_match.items():
+            (no_dup, dup)[pos_type_match[1] > 1].append(pos_type_match[0])
         dup_mod = "DupModPos"
         dup = set(dup)
         for pos in dup:
@@ -471,7 +473,8 @@ def validate_modification(pep_seq, mod_pos, mod_type):
                     "rule": dup_mod,
                     "value": pos,
                     "field": "mod_pos",
-                    "message": f"{pos} appears more than once in modification positions.",
+                    "message": f"{pos} with same modification type appears"
+                    " more than once in modification positions.",
                     "suggestion": None,
                 }
             )

--- a/tetramer_validator/validate.py
+++ b/tetramer_validator/validate.py
@@ -418,6 +418,7 @@ def validate_modification(pep_seq, mod_pos, mod_type):
         for pos in positions.items():
             (no_dup, dup)[pos[1] > 1].append(pos[0])
         dup_mod = "DupModPos"
+        dup = set(dup)
         for pos in dup:
             errors.append(
                 {

--- a/tetramer_validator/validate.py
+++ b/tetramer_validator/validate.py
@@ -1,6 +1,7 @@
 import csv
 import re
 from os import path
+from collections import Counter
 
 here = path.abspath(path.dirname(__file__))
 molecule_file = "data/molecule.tsv"
@@ -410,6 +411,25 @@ def validate_modification(pep_seq, mod_pos, mod_type):
                 return errors
 
     errors.extend(validate_mod_pos(pep_seq, positions))
+    if not errors:
+        positions, mod_types = format_mod_info(mod_pos, mod_type)
+        positions = Counter(positions.split(","))
+        dup, no_dup = [], []
+        for pos in positions.items():
+            (no_dup, dup)[pos[1] > 1].append(pos[0])
+        dup_mod = "DupModPos"
+        for pos in dup:
+            errors.append(
+                {
+                    "level": "warn",
+                    "rule": dup_mod,
+                    "value": pos,
+                    "field": "mod_pos",
+                    "message": f"{pos} appears more than once in modification positions.",
+                    "suggestion": None,
+                }
+            )
+
     return errors
 
 


### PR DESCRIPTION
Example: http://tetramers.iedb.org/?mhc_name=HLA-B*07%3A05&pep_seq=MMMMMMMMMMMMMMMMMMMMMMMMMMMMM&mod_type=formylated+residue%2C+formylated+residue%2C+formylated+residue%2C+formylated+residue%2C+formylated+residue%2C+formylated+residue%2C+formylated+residue&mod_pos=M6%2CM6%2CM6%2CM6%2CM6%2CM6%2CM9

No more than 1 modification per position.  